### PR TITLE
Filter out node_modules results and also choose top-level if multiple

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"testing/fstest"
+)
+
+func TestGetLangs(t *testing.T) {
+	testFs := fstest.MapFS{
+		"README.md":            {},
+		"foo/package.json":     {},
+		"foo/bar/package.json": {}, // We want to ignore this and use the top-level when both present.
+		"my-go-project/go.mod": {},
+	}
+
+	got := getLangs(testFs)
+	want := map[string]string{
+		"go":         "/my-go-project",
+		"typescript": "/foo",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+func TestFindFiles(t *testing.T) {
+	testFs := fstest.MapFS{
+		"README.md":                   {},
+		"cdk/node_modules/foo/go.mod": {}, // We've seen real examples like this.
+		"my-go-project/go.mod":        {},
+	}
+
+	got := findFiles(testFs, "go.mod", []string{"node_modules"})
+	want := []string{"my-go-project/go.mod"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}


### PR DESCRIPTION
E.g. we want to ignore:

`cdk/node_modules/foo/go.mod`

and we want to pick the top-level `package.json` etc if multiple found.