### PR TITLE
fix go package manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ updates:
         patterns: ["*"]
 {{ end }}
 {{ if .go }}
-  - package-ecosystem: "go"
+  - package-ecosystem: "gomod"
     directory: "{{ .go }}"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

`go` is not the package manager for `go`. Use `gomod` instead

## How to test

I used `configure-dependency-management` to raise a PR ( #7 ) against itself. It failed. #9 was raised using this branch, and has the correct package manager

## How can we measure success?

PRs will be raised by dependabot against this repo
